### PR TITLE
feat: add random suffix to report-filename to avoid clashes on parallel runs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -81,6 +81,8 @@ runs:
           fs_basename="$(basename $FILESYSTEM_REFERENCE)"
           report_filename="${fs_basename}-${{ github.run_id }}"
         fi
+        report_filename="${report_filename}-$(openssl rand -hex 3)"
+
         echo "report_filename=$report_filename" >> $GITHUB_OUTPUT
 
     - name: Run Trivy Scan


### PR DESCRIPTION
fixes: #6

This PR adds a random 3 bytes hex suffix to the filename used in the `upload-artifact` action.
